### PR TITLE
calc feature metadata

### DIFF
--- a/q2_longitudinal/_longitudinal.py
+++ b/q2_longitudinal/_longitudinal.py
@@ -23,7 +23,8 @@ from ._utilities import (_get_group_pairs, _extract_distance_distribution,
                          _regplot_subplots_from_dataframe, _load_metadata,
                          _validate_input_values, _validate_input_columns,
                          _nmit, _validate_is_numeric_column,
-                         _tabulate_matrix_ids, _first_differences)
+                         _tabulate_matrix_ids, _first_differences,
+                         _summarize_feature_stats)
 from ._vega import _render_volatility_spec
 
 
@@ -221,6 +222,11 @@ def _volatility(metadata, table, importances, output_dir, state_column,
         metadata = metadata.filter_columns(column_type='categorical')
         metadata = metadata.merge(qiime2.Metadata(state_md_col))
 
+        # Compile first differences and other stats on feature data
+        feature_md = _summarize_feature_stats(table, state_md_col)
+        feature_md.to_csv(
+            os.path.join(output_dir, 'feature_metadata.tsv'), sep='\t')
+
     # Convert table to metadata and merge, if present.
     if table is not None:
         table.index.name = 'id'
@@ -305,11 +311,15 @@ def volatility(output_dir: str, metadata: qiime2.Metadata,
                        default_metric, yscale)
 
 
-def feature_volatility(output_dir: str, table: pd.DataFrame,
-                       importances: pd.DataFrame, metadata: qiime2.Metadata,
-                       state_column: str, individual_id_column: str=None,
-                       default_group_column: str=None,
-                       default_metric: str=None, yscale: str='linear') -> None:
+def visualize_feature_volatility(output_dir: str,
+                                 table: pd.DataFrame,
+                                 importances: pd.DataFrame,
+                                 metadata: qiime2.Metadata,
+                                 state_column: str,
+                                 individual_id_column: str=None,
+                                 default_group_column: str=None,
+                                 default_metric: str=None,
+                                 yscale: str='linear') -> None:
     return _volatility(metadata, table, importances, output_dir, state_column,
                        individual_id_column, default_group_column,
                        default_metric, yscale)

--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -741,3 +741,25 @@ def _validate_is_numeric_column(metadata, metric):
         raise ValueError('{0} is not a numeric metadata column. '
                          'Please choose a metadata column containing only '
                          'numeric values.'.format(metric))
+
+
+def _summarize_feature_stats(table, state_md_col):
+    feature_table = pd.concat([state_md_col, table], join='inner', axis=1)
+    # calculate mean at each state value
+    state = state_md_col.columns[0]
+    feature_state_mean = feature_table.groupby(state).mean()
+    # first differences of mean per state
+    first_diffs = feature_state_mean.diff().dropna()
+    # sum increase and decrease across states
+    feature_md = pd.DataFrame(index=table.columns)
+    feature_table.index.name = 'feature id'
+    feature_md['Cumulative Avg Decrease'] = first_diffs[first_diffs < 0].sum()
+    feature_md['Cumulative Avg Increase'] = first_diffs[first_diffs > 0].sum()
+    # collect other descriptive stats
+    feature_md['Variance'] = table.var()
+    feature_md['Mean'] = table.mean()
+    feature_md['Median'] = table.median()
+    feature_md['Standard Deviation'] = table.std()
+    feature_md['CV (%)'] = (
+        feature_md['Standard Deviation'] / feature_md['Mean'] * 100)
+    return feature_md

--- a/q2_longitudinal/plugin_setup.py
+++ b/q2_longitudinal/plugin_setup.py
@@ -20,8 +20,8 @@ from ._type import FirstDifferences
 from ._format import FirstDifferencesFormat, FirstDifferencesDirectoryFormat
 from ._longitudinal import (pairwise_differences, pairwise_distances,
                             linear_mixed_effects, volatility,
-                            feature_volatility, nmit, first_differences,
-                            first_distances)
+                            visualize_feature_volatility, nmit,
+                            first_differences, first_distances)
 import q2_longitudinal
 
 
@@ -249,7 +249,7 @@ plugin.visualizers.register_function(
 )
 
 plugin.visualizers.register_function(
-    function=feature_volatility,
+    function=visualize_feature_volatility,
     inputs={
         'table': FeatureTable[RelativeFrequency],
         'importances': FeatureData[Importance],

--- a/q2_longitudinal/tests/test_longitudinal.py
+++ b/q2_longitudinal/tests/test_longitudinal.py
@@ -25,7 +25,8 @@ from q2_longitudinal._utilities import (
     _multiple_group_difference, _per_method_pairwise_stats,
     _multiple_tests_correction, _add_sample_size_to_xtick_labels,
     _temporal_corr, _temporal_distance, _nmit, _validate_is_numeric_column,
-    _tabulate_matrix_ids, _validate_metadata_is_superset)
+    _tabulate_matrix_ids, _validate_metadata_is_superset,
+    _summarize_feature_stats)
 from q2_longitudinal._longitudinal import (
     pairwise_differences, pairwise_distances, linear_mixed_effects, volatility,
     nmit, first_differences, first_distances)
@@ -700,6 +701,22 @@ class TestLongitudinal(TestPluginBase):
         with self.assertRaisesRegex(ValueError, "Missing samples in metadata"):
             _validate_metadata_is_superset(
                 md[md['Time'] == 1], _tabulate_matrix_ids(dm))
+
+    def test_summarize_feature_stats(self):
+        cheap_md = pd.DataFrame({'time': [1, 1, 2, 2, 3, 3]},
+                                index=['s1', 's2', 's3', 's4', 's5', 's6'])
+        feature_md = _summarize_feature_stats(tab, cheap_md)
+        exp = pd.DataFrame(
+            [[0., 0.1, 0.016, 0.5, 0.55, 0.126491106, 25.2982213],
+             [-0.05, 0.05, 0.00666666667, 0.33333333333, 0.35, 0.0816496581,
+              24.4948974],
+             [-0.1, 0., 0.00666666667, 0.166666667, 0.15, 0.0816496581,
+              48.9897949]],
+            columns=['Cumulative Avg Decrease',
+                     'Cumulative Avg Increase', 'Variance',
+                     'Mean', 'Median', 'Standard Deviation', 'CV (%)'],
+            index=['o1', 'o2', 'o3'])
+        pdt.assert_frame_equal(feature_md, exp, check_names=False)
 
 
 md = pd.DataFrame([(1, 'a', 0.11, 1), (1, 'a', 0.12, 2), (1, 'a', 0.13, 3),


### PR DESCRIPTION
This calculates a bunch of stats as a df, some of which we will want to visualize as barplots in this viz.

Could be interesting to allow users to select which values to plot or even filter features interactively based on these values, but we can just put that on the wish list.

I renamed `feature_volatility` because that will be the pipeline name. This visualizer is also probably not something that should be run outside of the pipeline (since the importances make it pretty darn specific)
